### PR TITLE
install nams to make it work with binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
       - pymdown-extensions
       - mknotebooks
       - mkdocstrings
+      - git+http://github.com/ericmjl/Network-Analysis-Made-Simple@master


### PR DESCRIPTION
Binder build is currently broken.

@ericmjl Should we redirect users to JupyterLab interface + maybe the introduction notebook from the launch binder link?