### PR TITLE
NodeViews not keyed on a node ID

### DIFF
--- a/notebooks/01-introduction/02-networkx-intro.ipynb
+++ b/notebooks/01-introduction/02-networkx-intro.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "Nodes are part of the attribute `G.nodes`.\n",
     "There, the node data are housed in a dictionary-like container,\n",
-    "where the key is the node ID\n",
+    "where the key is the node itself\n",
     "and the values are a dictionary of attributes. \n",
     "Node data are accessible using syntax that looks like:\n",
     "\n",


### PR DESCRIPTION
Thanks for a great resource! Minor suggestion here.

In Data Model, you write that the keys in NodeViews are "Node IDs": 
![image](https://user-images.githubusercontent.com/39198770/134745458-e3443406-8b04-400f-bed8-0f41b6406928.png)

If I'm not mistaken, the keys are _the nodes themselves_, which is why networkx requires any custom node objects be hashable. This is a very fine point, but after spending a couple hours trying and failing to query custom node objects by ID, I feel it's an important one.

```python
class MyNode():
    def __init__(self):
        self.type = 'mynode'

G = nx.Graph()
n2 = MyNode()

G.add_node('node1', exp_type='str')
G.add_node(n2, exp_type='node obj')

# If your node is a string literal, you might:
G.nodes['node1']  # this might pass for a node ID, the string literal 'node1' is the dictionary key - the node itself
# {'exp_type': 'str'}

# If your node is an custom object, you have to query with the object itself:
G.nodes[n2]  # this variable points at the MyNode object itself, not an ID
# {'exp_type': 'node obj'}

for node in G:
    print(type(node))
# <class 'str'>
# <class '__main__.MyNode'>

```