### PR TITLE
feat(environment): allow Python version flexibility and update dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,10 @@ name: nams # Network Analysis Made Simple
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python>=3.9
   - black
   - ffmpeg
   - gitpython  # used by mkdocs
-  - hiveplot
   - ipykernel
   - isort
   - jupyter
@@ -21,7 +20,6 @@ dependencies:
   - nbstripout>=0.3.9
   - networkx>=2.6.3
   - numpy
-  - nxviz
   - pandas>=1.0
   - pip
   - pre-commit
@@ -36,3 +34,4 @@ dependencies:
   - tqdm
   - pip:
     - mknotebooks
+    - nxviz

--- a/notebooks/01-introduction/03-viz.ipynb
+++ b/notebooks/01-introduction/03-viz.ipynb
@@ -165,7 +165,7 @@
    },
    "outputs": [],
    "source": [
-    "import nxviz as nv \n",
+    "import nxviz as nv\n",
     "from nxviz import annotate\n",
     "\n",
     "\n",
@@ -294,7 +294,7 @@
    "outputs": [],
    "source": [
     "from nxviz import plots\n",
-    "import matplotlib.pyplot as plt \n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "nv.hive(G, group_by=\"gender\", node_color_by=\"gender\")\n",
     "annotate.hive_group(G, group_by=\"gender\")"
@@ -355,7 +355,7 @@
   "kernelspec": {
    "display_name": "nams",
    "language": "python",
-   "name": "nams"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -367,7 +367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Update the Python version requirement to be more flexible, allowing any version greater than or equal to 3.9.
- Remove the `hiveplot` dependency from the main list.
- Move `nxviz` from the main dependency list to the `pip` subsection, ensuring it is installed via pip.

This change will help in maintaining compatibility with future Python releases and streamline dependency management by specifying the preferred installation method for `nxviz`.