### PR TITLE
Add missing dependencies

### DIFF
--- a/notebooks/02-algorithms/01-hubs.py
+++ b/notebooks/02-algorithms/01-hubs.py
@@ -9,6 +9,7 @@
 #     "networkx==3.4.2",
 #     "nxviz==0.7.6",
 #     "pandas==2.2.3",
+#     "pyarrow==20.0.0",
 #     "pyprojroot==0.3.0",
 #     "tqdm==4.67.1",
 # ]

--- a/notebooks/02-algorithms/02-paths.py
+++ b/notebooks/02-algorithms/02-paths.py
@@ -8,6 +8,7 @@
 #     "networkx==3.4.2",
 #     "nxviz==0.7.6",
 #     "pandas==2.2.3",
+#     "pyarrow==20.0.0",
 #     "pyprojroot==0.3.0",
 #     "seaborn==0.13.2",
 #     "tqdm==4.67.1",

--- a/notebooks/04-advanced/01-bipartite.py
+++ b/notebooks/04-advanced/01-bipartite.py
@@ -8,6 +8,9 @@
 #     "networkx==3.4.2",
 #     "nxviz==0.7.6",
 #     "pandas==2.2.3",
+#     "pyarrow==20.0.0",
+#     "pyprojroot==0.3.0",
+#     "tqdm==4.67.1",
 # ]
 # [[tool.uv.index]]
 # name = "ericmjl-personal-packages"

--- a/notebooks/04-advanced/03-stats.py
+++ b/notebooks/04-advanced/03-stats.py
@@ -9,6 +9,8 @@
 #     "networkx==3.4.2",
 #     "nxviz==0.7.6",
 #     "pandas==2.2.3",
+#     "pyjanitor==0.31.0",
+#     "pyprojroot==0.3.0",
 #     "scipy==1.15.2",
 #     "seaborn==0.13.2",
 #     "tqdm==4.67.1",

--- a/notebooks/05-casestudies/02-airport.py
+++ b/notebooks/05-casestudies/02-airport.py
@@ -9,6 +9,9 @@
 #     "numpy==2.2.5",
 #     "nxviz==0.7.6",
 #     "pandas==2.2.3",
+#     "pyprojroot==0.3.0",
+#     "scipy==1.15.2",
+#     "tqdm==4.67.1",
 # ]
 # [[tool.uv.index]]
 # name = "ericmjl-personal-packages"


### PR DESCRIPTION
`pyarrow` dependency is optional, but having it adds nice flourishes to viewing tables (and avoids a warning message). Marimo prompts to install the other missing dependencies, but I don't think it suggests `pyarrow`.

Marimo recommends installing `janitor` instead of `pyjanitor`.

Also of note is that `notebooks/04-advanced/02-linalg.py` needs `ffmpeg` installed in the system (`conda install -c condo-forge ffmpeg` also works).